### PR TITLE
Fixed import paths to begin with 'respyte.'

### DIFF
--- a/respyte/__init__.py
+++ b/respyte/__init__.py
@@ -8,8 +8,8 @@ Implementation of open-source vrsion of RESP method
 from __future__ import absolute_import
 
 # Add imports here
-from .esp_generator import *
-from .resp_optimizer import *
+from respyte.esp_generator import *
+from respyte.resp_optimizer import *
 
 # Handle versioneer
 from ._version import get_versions

--- a/respyte/esp_generator.py
+++ b/respyte/esp_generator.py
@@ -6,11 +6,11 @@ Implementation of open-source vrsion of RESP method
 import os, sys
 import numpy as np
 from shutil import copyfile
-from .readinp_esp import *
-from .readmol import * # read molecules and assign (what?)
-from .molecule import * # copied from forcebalance package and modified
-from .gen_grid_pts import * # take either rdkit ol or oechem mol to generate grid points around molecules (modified CIB's code)
-from .engine import *
+from respyte.readinp_esp import *
+from respyte.readmol import * # read molecules and assign (what?)
+from respyte.molecule import * # copied from forcebalance package and modified
+from respyte.gen_grid_pts import * # take either rdkit ol or oechem mol to generate grid points around molecules (modified CIB's code)
+from respyte.engine import *
 
 def main():
     # cwd = current working directory in which input folder exists

--- a/respyte/gen_grid_pts.py
+++ b/respyte/gen_grid_pts.py
@@ -56,7 +56,7 @@ except ImportError:
 
 # import molecule module copied from ForceBalance package
 # just in case a user doesn't use any cheminformatics
-from .molecule import *
+from respyte.molecule import *
 
 def GenerateVdwNeighborList( mol, atomi, scalefac, moltype = 'OEMol'):
     '''Scaling the atomic radii by scalefac, this function returns a list of OEAtoms

--- a/respyte/molecule.py
+++ b/respyte/molecule.py
@@ -265,7 +265,7 @@ def elem_from_atomname(atomname):
 #| PDB read/write functions |#
 #============================#
 try:
-    from PDB import *
+    from respyte.PDB import *
 except ImportError:
     warn('The pdb module cannot be imported (Cannot read/write PDB files)')
 
@@ -273,7 +273,7 @@ except ImportError:
 #| Mol2 read/write functions |#
 #=============================#
 try:
-    import Mol2
+    import respyte.Mol2
 except ImportError:
     warn('The Mol2 module cannot be imported (Cannot read/write Mol2 files)')
 

--- a/respyte/molecule_resp.py
+++ b/respyte/molecule_resp.py
@@ -15,7 +15,7 @@ except ImportError:
 from respyte.molecule import *
 from respyte.readinp_resp import Input
 from pathlib import Path
-from readmol import *
+from respyte.readmol import *
 
 bohr2Ang = 0.52918825 # change unit from bohr to angstrom
 

--- a/respyte/readmol.py
+++ b/respyte/readmol.py
@@ -10,7 +10,7 @@ except ImportError:
 
 # import molecule module copied from ForceBalance package
 # just in case a user doesn't use any cheminformatics
-from .molecule import *
+from respyte.molecule import *
 
 BondiRadii = [1.2, 1.4, # exchanged None to 2.0
               1.81, 2.0, 2.0, 1.70, 1.55, 1.52, 1.47, 1.54,

--- a/respyte/resp_optimizer.py
+++ b/respyte/resp_optimizer.py
@@ -1,10 +1,10 @@
 
-from molecule import *
-from readinp_resp import Input
-from molecule_resp import *
-from select_grid import *
+from respyte.molecule import *
+from respyte.readinp_resp import Input
+from respyte.molecule_resp import *
+from respyte.select_grid import *
 
-from .resp_unit import *
+from respyte.resp_unit import *
 
 
 def main():

--- a/respyte/resp_unit.py
+++ b/respyte/resp_unit.py
@@ -14,8 +14,8 @@ try:
 except ImportError:
     warn(' The Openeye module cannot be imported. ( Please provide equivGoups and listofpolar manually.)')
 
-from molecule import *
-from readinp_resp import Input
+from respyte.molecule import *
+from respyte.readinp_resp import Input
 
 # Global variables
 bohr2Ang = 0.52918825 # change unit from bohr to angstrom

--- a/respyte/select_grid.py
+++ b/respyte/select_grid.py
@@ -1,4 +1,4 @@
-from .molecule import *
+from respyte.molecule import *
 
 BondiRadii = [1.2, 1.4, # exchanged None to 2.0
               1.81, 2.0, 2.0, 1.70, 1.55, 1.52, 1.47, 1.54,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,9 @@ setup(
     license='BSD-3-Clause',
 
     # Which Python importable modules should be included when your package is installed
-    packages=['respyte', "respyte.tests"],
+    packages=['respyte',
+              #"respyte.molecule",
+              "respyte.tests"],
 
     # Optional include package data to ship with your package
     # Comment out this line to prevent the files from being packaged with your software


### PR DESCRIPTION
## Description
Fixed import paths to begin with 'respyte.'

This should help get Travis testing online, as modules can now correctly be implemented.